### PR TITLE
Add explicit `encoding = "utf-8"` for `open`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 import sys
+import io
 from setuptools import find_packages, setup, Command
 
 
 EXCLUDE_FROM_PACKAGES = []
 
-readme = open('README.rst', 'r', encoding = "utf-8").read()
+readme = io.open('README.rst', 'r', encoding = "utf-8").read()
 
 class TestCommand (Command):
     description = 'test task'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup, Command
 
 EXCLUDE_FROM_PACKAGES = []
 
-readme = open('README.rst', 'r').read()
+readme = open('README.rst', 'r', encoding = "utf-8").read()
 
 class TestCommand (Command):
     description = 'test task'


### PR DESCRIPTION
The default encoding of `open` on Windows (Chinese Simplified) is "GBK", which will cause an `UnicodeDecodeError` when `open('README.rst', 'r').read()`