### PR TITLE
Fixes 'STARTUP_WITH_SHELL_OFF' is not defined

### DIFF
--- a/gdbgui/backend.py
+++ b/gdbgui/backend.py
@@ -43,10 +43,9 @@ DEFAULT_GDB_EXECUTABLE = 'gdb'
 DEFAULT_GDB_ARGS = ['-nx', '--interpreter=mi2']
 DEFAULT_LLDB_ARGS = ['--interpreter=mi2']
 
+STARTUP_WITH_SHELL_OFF = False
 match = re.match('darwin-(\d+)\..*', platform.platform().lower())
-if match is None:
-    STARTUP_WITH_SHELL_OFF = False
-elif int(match.groups()[0]) >= 16:
+if match is not None and int(match.groups()[0]) >= 16:
     # if mac OS version is 16 (sierra) or higher, need to set shell off due to
     # os's security requirements
     STARTUP_WITH_SHELL_OFF = True


### PR DESCRIPTION
Fixes:

```python
NameError: global name 'STARTUP_WITH_SHELL_OFF' is not defined
```