### PR TITLE
BUG FIX: container `empty -> 1 element` bug fix

### DIFF
--- a/gdbgui/static/js/gdbgui.js
+++ b/gdbgui/static/js/gdbgui.js
@@ -2602,33 +2602,30 @@ const Expressions = {
     handle_changelist: function(changelist_array){
         for(let changelist of changelist_array){
             let expressions = state.get('expressions')
-            , expr_type = state.get("expr_type")
             , obj = Expressions.get_obj_from_gdb_var_name(expressions, changelist.name)
-
             if(obj){
                 if(parseInt(changelist['has_more']) === 1 && 'name' in changelist){
                     // already retrieved children of obj, but more fields were added.
                     // Re-fetch the object from gdb
-                    Expressions._get_children_for_var(changelist['name'], expr_type)
-                } else {
-                    if('new_children' in changelist){
-                        let new_children = changelist.new_children.map(child_obj => Expressions.prepare_gdb_obj_for_storage(child_obj, expr_type))
-                        obj.children = obj.children.concat(new_children)
-                    }
-                    if('value' in changelist && obj.expr_type === 'expr'){
-                        // this object is an expression and it had a value updated.
-                        // save the value to an array for plotting
-                        if(changelist.value.indexOf('0x') === 0){
-                            obj.can_plot = true
-                            obj.values.push(parseInt(changelist.value, 16))
-                        }else if (!window.isNaN(parseFloat(changelist.value))){
-                            obj.can_plot = true
-                            obj.values.push(changelist.value)
-                        }
-                    }
-                    // overwrite fields of obj with fields from changelist
-                    _.assign(obj, changelist)
+                    Expressions._get_children_for_var(changelist['name'], obj.expr_type)
                 }
+                if('new_children' in changelist){
+                    let new_children = changelist.new_children.map(child_obj => Expressions.prepare_gdb_obj_for_storage(child_obj, obj.expr_type))
+                    obj.children = obj.children.concat(new_children)
+                }
+                if('value' in changelist && obj.expr_type === 'expr'){
+                    // this object is an expression and it had a value updated.
+                    // save the value to an array for plotting
+                    if(changelist.value.indexOf('0x') === 0){
+                        obj.can_plot = true
+                        obj.values.push(parseInt(changelist.value, 16))
+                    }else if (!window.isNaN(parseFloat(changelist.value))){
+                        obj.can_plot = true
+                        obj.values.push(changelist.value)
+                    }
+                }
+                // overwrite fields of obj with fields from changelist
+                _.assign(obj, changelist)
                 // update expressions array which will trigger and event, which will
                 // cause components to re-render
                 state.set('expressions', expressions)

--- a/gdbgui/static/js/gdbgui.js
+++ b/gdbgui/static/js/gdbgui.js
@@ -2602,13 +2602,13 @@ const Expressions = {
     handle_changelist: function(changelist_array){
         for(let changelist of changelist_array){
             let expressions = state.get('expressions')
-            let expr_type = state.get("expr_type")
+            , expr_type = state.get("expr_type")
             , obj = Expressions.get_obj_from_gdb_var_name(expressions, changelist.name)
 
             if(obj){
-                if(changelist['has_more'] == 1 && 'name' in changelist){
-                    // already retrieved children of obj
-                    obj.has_more = 0
+                if(parseInt(changelist['has_more']) === 1 && 'name' in changelist){
+                    // already retrieved children of obj, but more fields were added.
+                    // Re-fetch the object from gdb
                     Expressions._get_children_for_var(changelist['name'], expr_type)
                 } else {
                     if('new_children' in changelist){


### PR DESCRIPTION
I think this should work.

Can't perform `-var-set-update-range <varname> 0 <new_num_children>` because `new_num_children` isn't present in `changelist` in this situation, but only 'has_more'.

Also, `-var-set-update-range <varname> 0 <new_num_children>` with `new_num_children` specified by hand doesn't work either. Not sure why.

But `Expressions._get_children_for_var` (aka. `-var- list-children`) seems working. 