### PR TITLE
Added required cygwin packages to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ macOS users should run this for system wide installations:
 
     sudo pip install gdbgui --upgrade --user
 
-Windows has been tested to work with `cygwin <https://cygwin.com/install.html>`_.
+Windows has been tested to work with `cygwin <https://cygwin.com/install.html>`_ with the python3, python3-pip, python3-devel, gdb, gcc-core, and gcc-g++ cygwin packages installed.
 
 manually
 ~~~~~~~~


### PR DESCRIPTION
You may not want to pull this request to avoid cluttering the README too much but I spent a day figuring out why gdbgui couldn't detect gdb. I realized at the end that gdbgui cannot be compiled using MinGW and python installed outside of cygwin so this may help a developer somewhere.