### PR TITLE
README.rst: fix FreeBSD's name and remove unnecessary trailing slashes from URLS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,9 +227,9 @@ and `contributions from the community <https://github.com/cs01/gdbgui/graphs/con
 Users of gdbgui
 --------------------------------
 
-- `Arch Linux <https://www.archlinux.org//>`_
+- `Arch Linux <https://www.archlinux.org/>`_
 - `BlackArch Linux <https://www.blackarch.org/>`_
-- `FreeBSD <https://www.freebsd.org//>`_
+- `FreeBSD <https://www.freebsd.org/>`_
 - Create a PR and add your name, school, or project here
 
 Contact

--- a/README.rst
+++ b/README.rst
@@ -229,7 +229,7 @@ Users of gdbgui
 
 - `Arch Linux <https://www.archlinux.org//>`_
 - `BlackArch Linux <https://www.blackarch.org/>`_
-- `Free BSD <https://www.freebsd.org//>`_
+- `FreeBSD <https://www.freebsd.org//>`_
 - Create a PR and add your name, school, or project here
 
 Contact


### PR DESCRIPTION
This PR is kind of pedantic.

FreeBSD != "Free BSD". (https://www.freebsdfoundation.org/about/project/). The additional trailing slash in a couple URLs are unnecessary as well.