### PR TITLE
change socket to relative path

### DIFF
--- a/gdbgui/src/js/GdbApi.jsx
+++ b/gdbgui/src/js/GdbApi.jsx
@@ -31,7 +31,6 @@ if(debug){
 const GdbApi = {
     init: function(){
         const TIMEOUT_MIN = 5
-
         /* global io */
        GdbApi.socket = io.connect(`/gdb_listener`, {timeout: TIMEOUT_MIN * 60 * 1000});
 

--- a/gdbgui/src/js/GdbApi.jsx
+++ b/gdbgui/src/js/GdbApi.jsx
@@ -31,8 +31,11 @@ if(debug){
 const GdbApi = {
     init: function(){
         const TIMEOUT_MIN = 5
+	console.log("setting socket "+document);
+
         /* global io */
-        GdbApi.socket = io.connect(`http://${document.domain}:${location.port}/gdb_listener`, {timeout: TIMEOUT_MIN * 60 * 1000});
+       GdbApi.socket = io.connect(`/gdb_listener`, {timeout: TIMEOUT_MIN * 60 * 1000});
+
 
         GdbApi.socket.on('connect', function(){
             debug_print('connected')

--- a/gdbgui/src/js/GdbApi.jsx
+++ b/gdbgui/src/js/GdbApi.jsx
@@ -31,7 +31,6 @@ if(debug){
 const GdbApi = {
     init: function(){
         const TIMEOUT_MIN = 5
-	console.log("setting socket "+document);
 
         /* global io */
        GdbApi.socket = io.connect(`/gdb_listener`, {timeout: TIMEOUT_MIN * 60 * 1000});


### PR DESCRIPTION
Remove hard-coded http protocol so it can work on https via reverse proxy. 
(Mixing http and https is not allowed in some browsers.) 
Using /gdb_listener works for me... but you could also use the document.protocol instead of http. 