### PR TITLE
Issue #194: Change --args to match 'gdb --args'. 'cmd' now only takes program name.

### DIFF
--- a/gdbgui/backend.py
+++ b/gdbgui/backend.py
@@ -766,18 +766,6 @@ def main():
     other = parser.add_argument_group(title="other settings")
 
     gdb_group.add_argument(
-        "cmd",
-        nargs="*",
-        help="The binary and arguments to run in gdb. Example: './mybinary myarg -flag1 -flag2'",
-        default=[],
-    )
-    gdb_group.add_argument(
-        "--args",
-        nargs="+",
-        help='Alias for cmd argument above. Example: gdbgui --args "./mybinary myarg -flag1 -flag2"',
-        default=[],
-    )
-    gdb_group.add_argument(
         "-x", "--gdb_cmd_file", help="Execute GDB commands from file."
     )
     gdb_group.add_argument(
@@ -864,6 +852,24 @@ def main():
         "Pass this flag when debugging gdbgui itself to automatically reload the server when changes are detected",
         action="store_true",
     )
+
+    gdb_group.add_argument(
+        "--args",
+        nargs=argparse.REMAINDER,
+        help='All remaining args are taken as the binary and arguments to run'
+            ' in gdb (as with gdb --args).'
+            ' Example: gdbgui [...] --args ./mybinary myarg -flag1 -flag2',
+        default=[],
+    )
+    gdb_group.add_argument(
+        "cmd",
+        nargs='?',
+        help='Name of the binary to run in gdb. To pass flags to the binary,'
+            ' use --args.'
+            ' Example: gdbgui ./mybinary [gdbgui-args...]',
+        default=[],
+    )
+
     args = parser.parse_args()
 
     initialize_preferences()

--- a/gdbgui/backend.py
+++ b/gdbgui/backend.py
@@ -866,9 +866,10 @@ def main():
     args_group.add_argument(
         "--args",
         nargs=argparse.REMAINDER,
-        help='All remaining args are taken as the binary and arguments to run'
-            ' in gdb (as with gdb --args).'
-            ' Example: gdbgui [...] --args ./mybinary myarg -flag1 -flag2',
+        help='Specify the executable file and any arguments. All arguments are'
+             ' taken literally, so if used, this must be the last argument'
+             ' passed to gdbgui.'
+             ' Example: gdbgui [...] --args ./mybinary myarg -flag1 -flag2',
         default=[],
     )
 

--- a/gdbgui/backend.py
+++ b/gdbgui/backend.py
@@ -761,6 +761,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
 
     gdb_group = parser.add_argument_group(title="gdb commands")
+    args_group = parser.add_mutually_exclusive_group()
     network = parser.add_argument_group(title="gdbgui network settings")
     security = parser.add_argument_group(title="security settings")
     other = parser.add_argument_group(title="other settings")
@@ -853,20 +854,21 @@ def main():
         action="store_true",
     )
 
-    gdb_group.add_argument(
+    args_group.add_argument(
+        "cmd",
+        nargs='?',
+        type=lambda prog : [prog],
+        help='Name of the binary to run in gdb. To pass flags to the binary,'
+            ' use --args instead.'
+            ' Example: gdbgui ./mybinary [gdbgui-args...]',
+        default=[],
+    )
+    args_group.add_argument(
         "--args",
         nargs=argparse.REMAINDER,
         help='All remaining args are taken as the binary and arguments to run'
             ' in gdb (as with gdb --args).'
             ' Example: gdbgui [...] --args ./mybinary myarg -flag1 -flag2',
-        default=[],
-    )
-    gdb_group.add_argument(
-        "cmd",
-        nargs='?',
-        help='Name of the binary to run in gdb. To pass flags to the binary,'
-            ' use --args.'
-            ' Example: gdbgui ./mybinary [gdbgui-args...]',
         default=[],
     )
 
@@ -878,13 +880,7 @@ def main():
         print(__version__)
         return
 
-    if args.cmd and args.args:
-        print("Cannot specify command and args. Must specify one or the other.")
-        exit(1)
-    if args.cmd:
-        cmd = args.cmd
-    else:
-        cmd = args.args
+    cmd = args.cmd or args.args
 
     app.config["initial_binary_and_args"] = cmd
     app.config["rr"] = args.rr


### PR DESCRIPTION
Here is a patch which does what I think is reasonable: causes --args to take all remaining arguments as program arguments as with 'gdb --args'. The 'cmd' argument only takes the program name now. There are three options for 'cmd':

 1. Leave 'cmd' as nargs='*'; then any flags passed as '-' are ambiguous with gdbgui arguments unless the entire command string is qutoed, in which case it might as well be nargs=1. (i.e. `gdbgui [gdbgui-args] cmd [these-are-more-gdbgui-args]`)
 1. Set 'cmd' as nargs=1; this essentially works the same as above, but shows this explicitly in the usage string. Then to pass a full command string you would either do `gdgbui 'quoted-command --with-arguments' [gdbgui-args...]`.
 1. Set 'cmd' as nargs=`argparse.REMAINDER`; in this case the first non-option argument would begin debug program arguments. This acts more like non-GNU option parsing, i.e. `gdbgui [gdbgui-options] cmd-name [cmd-arguments...]`. However, with '--args' already set to `argparse.REMAINDER`, the two are equivalent. And then it is possible confusing if you want to do something like `gdbgui cmd-name --no-browser`, because `--no-browser` would be interpreted as a command arg.

For this reason I chose the second option. It is still convenient to debug simply with `gdbgui [gdbgui-args...] program` but you have gdb-like control with `gdbgui --args program [program-args...]`.
