### PR TITLE
WIP: Show number of times breakpoint was hit

### DIFF
--- a/gdbgui/src/js/Breakpoints.jsx
+++ b/gdbgui/src/js/Breakpoints.jsx
@@ -66,6 +66,22 @@ class Breakpoint extends React.Component {
       </div>
     );
   }
+  get_num_times_hit(bkpt){
+
+    if (bkpt.times === undefined) {
+      return "" // E.g. 'bkpt' is a child breakpoint
+    }
+
+    if (bkpt.times == 0) {
+      return "breakpoint never hit"
+    }
+    else if (bkpt.times == 1) {
+      return "breakpoint already hit 1 time"
+    }
+    else {
+      return "breakpoint already hit " + bkpt.times + " times";
+    }
+  }
   render() {
     let b = this.props.bkpt,
       checked = b.enabled === "y" ? "checked" : "",
@@ -111,6 +127,7 @@ class Breakpoint extends React.Component {
     } else {
       let func = b.func === undefined ? "(unknown function)" : b.func;
 
+      const times_hit = this.get_num_times_hit(b);
       function_jsx = (
         <div style={{ display: "inline" }}>
           <span className="monospace" style={{ paddingRight: "5px" }}>
@@ -118,6 +135,9 @@ class Breakpoint extends React.Component {
           </span>
           <span style={{ color: "#bbbbbb", fontStyle: "italic" }}>
             thread groups: {b["thread-groups"]}
+          </span>
+          <span style={{ color: "#bbbbbb", fontStyle: "italic", paddingLeft: "5px"}}>
+            {times_hit}
           </span>
         </div>
       );

--- a/gdbgui/src/js/Breakpoints.jsx
+++ b/gdbgui/src/js/Breakpoints.jsx
@@ -67,19 +67,14 @@ class Breakpoint extends React.Component {
     );
   }
   get_num_times_hit(bkpt){
-
-    if (bkpt.times === undefined) {
-      return "" // E.g. 'bkpt' is a child breakpoint
-    }
-
-    if (bkpt.times == 0) {
-      return "breakpoint never hit"
-    }
-    else if (bkpt.times == 1) {
-      return "breakpoint already hit 1 time"
-    }
-    else {
-      return "breakpoint already hit " + bkpt.times + " times";
+    if ((bkpt.times === undefined) // E.g. 'bkpt' is a child breakpoint
+          || 
+        (bkpt.times == 0)) {
+      return "" 
+    } else if (bkpt.times == 1) {
+      return "1 hit"
+    } else {
+      return `${bkpt.times} hits`;
     }
   }
   render() {


### PR DESCRIPTION
# Summary

Display the breakpoint's 'times' field when the 'Breakpoint' component is rendered. Do not display a hit count if the breakpoint is a child breakpoint or if the breakpoint has never been hit.

Here's a screenshot of the modified breakpoint component: 

<img width="1279" alt="breakpoint_hits_refactored" src="https://user-images.githubusercontent.com/15800423/60993057-98044b80-a345-11e9-8e8b-90b55d8dfe10.png">

Closes #187 