### PR TITLE
Ensure "--args" is last argument of gdb command

### DIFF
--- a/gdbgui/statemanager.py
+++ b/gdbgui/statemanager.py
@@ -2,11 +2,11 @@ import logging
 import traceback
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
-
+import copy
 from pygdbmi.gdbcontroller import GdbController  # type: ignore
 
-REQUIRED_GDB_FLAGS = ["--interpreter=mi2"]
 logger = logging.getLogger(__name__)
+GDB_MI_FLAG = ["--interpreter=mi2"]
 
 
 class StateManager(object):
@@ -18,7 +18,7 @@ class StateManager(object):
         self.config = config
 
     def get_gdb_args(self):
-        gdb_args = REQUIRED_GDB_FLAGS
+        gdb_args = copy.copy(GDB_MI_FLAG)
         if self.config["gdb_args"]:
             gdb_args += self.config["gdb_args"]
 

--- a/gdbgui/statemanager.py
+++ b/gdbgui/statemanager.py
@@ -46,10 +46,11 @@ class StateManager(object):
             logger.info("new sid", client_id)
 
             gdb_args = (
-                deepcopy(self.config["initial_binary_and_args"])
-                + deepcopy(self.config["gdb_args"])
-                + REQUIRED_GDB_FLAGS
-            )
+                REQUIRED_GDB_FLAGS
+                + self.config["gdb_args"]
+                + ["--args"]
+                + self.config["initial_binary_and_args"]
+            )            
 
             controller = GdbController(
                 gdb_path=self.config["gdb_path"],

--- a/gdbgui/statemanager.py
+++ b/gdbgui/statemanager.py
@@ -1,7 +1,6 @@
 import logging
 import traceback
 from collections import defaultdict
-from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
 from pygdbmi.gdbcontroller import GdbController  # type: ignore
@@ -50,7 +49,7 @@ class StateManager(object):
                 + self.config["gdb_args"]
                 + ["--args"]
                 + self.config["initial_binary_and_args"]
-            )            
+            )
 
             controller = GdbController(
                 gdb_path=self.config["gdb_path"],

--- a/gdbgui/statemanager.py
+++ b/gdbgui/statemanager.py
@@ -17,6 +17,16 @@ class StateManager(object):
         self.gdb_reader_thread = None
         self.config = config
 
+    def get_gdb_args(self):
+        gdb_args = REQUIRED_GDB_FLAGS
+        if self.config["gdb_args"]:
+            gdb_args += self.config["gdb_args"]
+
+        if self.config["initial_binary_and_args"]:
+            gdb_args += ["--args"]
+            gdb_args += self.config["initial_binary_and_args"]
+        return gdb_args
+
     def connect_client(self, client_id: str, desired_gdbpid: int) -> Dict[str, Any]:
         message = ""
         pid: Optional[int] = 0
@@ -44,12 +54,7 @@ class StateManager(object):
         if self.get_controller_from_client_id(client_id) is None:
             logger.info("new sid", client_id)
 
-            gdb_args = (
-                REQUIRED_GDB_FLAGS
-                + self.config["gdb_args"]
-                + ["--args"]
-                + self.config["initial_binary_and_args"]
-            )
+            gdb_args = self.get_gdb_args()
 
             controller = GdbController(
                 gdb_path=self.config["gdb_path"],

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,6 +8,7 @@ python = ["3.6", "3.7", "3.8"]
 
 doc_dependencies = [".", "mkdocs", "mkdocs-material"]
 lint_dependencies = ["black", "flake8", "mypy", "check-manifest"]
+files_to_lint = ["gdbgui", "tests"] + [str(p) for p in Path(".").glob("*.py")]
 
 
 @nox.session(python=python)
@@ -53,16 +54,21 @@ def lint(session):
         external=True,
     )
     session.install(*lint_dependencies)
-    files = ["gdbgui", "tests"] + [str(p) for p in Path(".").glob("*.py")]
-    session.run("black", "--check", *files)
-    session.run("flake8", *files)
-    session.run("mypy", *files)  #
+    session.run("black", "--check", *files_to_lint)
+    session.run("flake8", *files_to_lint)
+    session.run("mypy", *files_to_lint)  #
     session.run(
         "check-manifest",
         "--ignore",
         "build.js,gdbgui/static/js,gdbgui/static/js/build.js.map",
     )
     session.run("python", "setup.py", "check", "--metadata", "--strict")
+
+
+@nox.session(python="3.7")
+def autoformat(session):
+    session.install("black")
+    session.run("black", *files_to_lint)
 
 
 @nox.session(python="3.7")
@@ -76,7 +82,7 @@ def develop(session):
     session.install(*doc_dependencies, *lint_dependencies)
     session.install("-e", ".")
     command = "source %s/bin/activate" % (session.virtualenv.location_name)
-    session.log("Virtual Envrionment is ready to be used for development")
+    session.log("Virtual Environment is ready to be used for development")
     session.log("To use, run: '%s'", command)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,22 +1,30 @@
 import gdbgui
 import pytest  # type: ignore
 import sys
+from gdbgui.statemanager import StateManager, GDB_MI_FLAG
 
 
 @pytest.mark.parametrize(
-    "test_argv, init_bin_args, gdb_args",
+    "test_argv, expected_gdb_args",
     [
-        (["gdbgui"], [], []),
-        (["gdbgui", "--gdb-args", "mybin -myargs"], [], ["mybin", "-myargs"]),
-        (["gdbgui", "--args", "mybin", "-myargs"], ["mybin", "-myargs"], []),
+        (["gdbgui"], GDB_MI_FLAG),
+        (
+            ["gdbgui", "--gdb-args", "--nx --tty=/dev/ttys002 mybin -myargs"],
+            GDB_MI_FLAG + ["--nx", "--tty=/dev/ttys002", "mybin", "-myargs"],
+        ),
+        (
+            ["gdbgui", "-n", "--args", "mybin", "-myargs"],
+            GDB_MI_FLAG + ["--args", "mybin", "-myargs"],
+        ),
     ],
 )
-def test_argument_parsing(monkeypatch, test_argv, init_bin_args, gdb_args):
+def test_arguments_passed_to_gdb(monkeypatch, test_argv, expected_gdb_args):
     def mock_setup_backend(*args, **kwargs):
         pass
 
     monkeypatch.setattr(gdbgui.backend, "setup_backend", mock_setup_backend)
     monkeypatch.setattr(sys, "argv", test_argv)
     gdbgui.backend.main()
-    assert gdbgui.backend.app.config.get("initial_binary_and_args") == init_bin_args
-    assert gdbgui.backend.app.config.get("gdb_args") == gdb_args
+
+    state = StateManager(gdbgui.backend.app.config)
+    assert len(state.get_gdb_args()) == len(expected_gdb_args)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,6 +8,7 @@ from gdbgui.statemanager import StateManager, GDB_MI_FLAG
     "test_argv, expected_gdb_args",
     [
         (["gdbgui"], GDB_MI_FLAG),
+        (["gdbgui", "mybin -myargs"], GDB_MI_FLAG + ["mybin", "-myargs"]),
         (
             ["gdbgui", "--gdb-args", "--nx --tty=/dev/ttys002 mybin -myargs"],
             GDB_MI_FLAG + ["--nx", "--tty=/dev/ttys002", "mybin", "-myargs"],


### PR DESCRIPTION
To debug an application+command line arguments "--args" is used as last command line argument of gdbgui. Everything after "--args" must be passed then to gdb also as LAST command line argument.
This was not the case, but it is now ensured. By default gdb is now used in any case with "--args".

- I tested the code with gdb 8.3
- I removed the deepcopy() as it is IMHO not required.
