### PR TITLE
Bugfixes for building executable

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,7 +12,7 @@ gdbgui uses [https://github.com/theacodes/nox](nox) for to automate various task
 git clone https://github.com/cs01/gdbgui
 cd gdbgui
 nox -s develop-3.7  # replace with desired Python version
-source .nox/develop-3.7/bin/activate  # replace with desired Python version
+source .nox/develop-3-7/bin/activate  # replace with desired Python version
 ```
 
 You are now in a virtual environment with gdbgui's dependencies installed. When finished, type `deactivate` to leave the virtual environment.

--- a/make_executable.py
+++ b/make_executable.py
@@ -43,6 +43,11 @@ a = Analysis(['gdbgui/backend.py'],  # noqa
              hiddenimports=[
                'engineio.async_gevent',
                'engineio.async_threading',
+               'engineio.async_drivers.gevent',
+               'engineio.async_drivers.threading',
+               'engineio.async_drivers.eventlet',
+               'engineio.async_drivers.gevent_uwsgi',
+               'pkg_resources.py2_warn',
                ],
              hookspath=[],
              runtime_hooks=[],

--- a/noxfile.py
+++ b/noxfile.py
@@ -139,5 +139,5 @@ def docker_executables(session):
 
 @nox.session(python="3.7")
 def build_executable_current_os(session):
-    session.install("PyInstaller==3.3.1")
+    session.install(".", "PyInstaller<3.7")
     session.run("python", "make_executable.py")

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,8 +13,6 @@ files_to_lint = ["gdbgui", "tests"] + [str(p) for p in Path(".").glob("*.py")]
 
 @nox.session(python=python)
 def tests(session):
-    session.install(".")
-    tests = session.posargs or ["tests"]
     session.install(".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]
     session.run(
@@ -56,7 +54,7 @@ def lint(session):
     session.install(*lint_dependencies)
     session.run("black", "--check", *files_to_lint)
     session.run("flake8", *files_to_lint)
-    session.run("mypy", *files_to_lint)  #
+    session.run("mypy", *files_to_lint)
     session.run(
         "check-manifest",
         "--ignore",
@@ -125,7 +123,7 @@ def publish_docs(session):
 
 @nox.session(python="3.7")
 def docker_executables(session):
-    session.install("PyInstaller==3.3.1")
+    session.install(".", "PyInstaller<3.7")
     # Windows
     session.run(
         "docker", "build", "-t", "gdbgui_windows", "docker/windows", external=True

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ REQUIRED = [
     "Flask-Compress>=1.4.0, <2.0",  # to compress flask responses
     "Flask-SocketIO>=2.9, <3.0",  # websocket server
     "gevent>=1.2.2, <2.0",  # websocket handling
+    "gevent-websocket>=0.10.1, <0.11", # also websocket
+    "eventlet>=0.25.0, <0.26". # also websocket
     "pygdbmi>=0.9.0.0, <1.0",  # parse gdb output
     "Pygments>=2.2.0, <3.0",  # syntax highlighting
 ]


### PR DESCRIPTION
This commit has several bug fixes. Building on MacOS is broken by default without these changes:

- Add required python packages that were missing from setup.py; a clean computer install would throw an exception due to missing packages. 

- Add hiddenimports for pyinstaller, so that pyinstaller properly loads gevent

- Modify noxfile so that it loads the required packages when creating a session. Also, python 3.7 support was added in pyinstaller 3.4, so pyinstaller version needs to be updated.