### PR TITLE
Fix documentation for opening `rr replay`

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -64,13 +64,13 @@ gdbgui -r --auth --key private.key --cert host.cert
 
 Use Mozilla's [record and replay](https://rr-project.org) (rr) debugging supplement to gdb. rr lets your record a program (usually with a hard-to-reproduce bug in it), then deterministically replay it as many times as you want. You can even step forwards and backwards.
 ```
-gdbgui --gdb-cmd "rr replay"
+gdbgui --gdb-cmd "rr replay --"
 ```
 
 Use recording other than the most recent one
 
 ```
-gdbgui --gdb-cmd "rr replay RECORDED_DIRECTORY"
+gdbgui --gdb-cmd "rr replay RECORDED_DIRECTORY --"
 ```
 
 Don't automatically open the browser when launching


### PR DESCRIPTION
- [] I have added an entry to `docs/changelog.md`
(**I have not, since it is a minor documentation fix, but if it requires an entry to changelog, please let me know**)

## Summary of changes
The documentation in https://www.gdbgui.com/examples/ for `rr replay` causes an issue as it currently stands. In particular, the command provided `gdbgui --gdb-cmd "rr replay"` causes things to error our and quit instantly. The command should be updated to `gdbgui --gdb-cmd "rr replay --"` so that the extra arguments that gdbgui adds regarding new ui and such are passed along correctly to `gdb`.

## Test plan
Tested by running
```
# fails when running
gdbgui --gdb-cmd "rr replay"

# works great
gdbgui --gdb-cmd "rr replay --"
```
