### PR TITLE
fixes client using unsupported version of Socket.IO protocols

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         "pygdbmi>=0.10.0.0b0, <0.11",  # parse gdb output
         "Pygments>=2.2.0, <3.0",  # syntax highlighting
         "greenlet==0.4.16",
+        "python-socketio>=4.6.1, <5.0",  # pinned to use socketio 2 under the hood (issue #366)
     ],
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [ ] I have added an entry to `docs/changelog.md` 

**I defer to the @cs01 about what to add to the changelog here**


## Summary of changes

Issue https://github.com/cs01/gdbgui/issues/366


`python-socketio` released a new version that points to the new SocketIO v3. This is a major protocol update making v2 and v3 incompatible:

https://socket.io/docs/v3/migrating-from-2-x-to-3-0

> TL;DR: due to several breaking changes, a v2 client will not be able to connect to a v3 server (and vice versa)

This PR pins the server to use `>=4.6.1` of `python-socketio` which uses the v2 protocol, the same as what the client uses.

You can see a table that details the `python-socketio` version breakdown [here](https://pypi.org/project/python-socketio/).

## Test plan
N/A


