### PR TITLE
guides.md: simplify gdbserver call

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -100,7 +100,7 @@ Like gdb, [`gdbserver`](https://sourceware.org/gdb/onlinedocs/gdb/Server.html) i
 
 gdbserver runs on a remote machine or embedded target, which, as the name suggests, runs a server. gdb communicates with gdbserver so you can debug on your local machine. To do this, the remote machine must run the server and program:
 
-`gdbserver 0.0.0.0:9000 mybinary.a`
+`gdbserver :9000 mybinary.a`
 
 Then you can launch `gdb` or `gdbgui` and connect to it. In `gdbgui`, use the dropdown to select `Connect to gdbserver`, and enter
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [ ] I have added an entry to `docs/changelog.md`

## Summary of changes

gdb supports omitting IP address for cases when it's a "wait for
connection from anywhere". Make use of it to simplify the call.

## Test plan

Not needed *(documentation change)*.
