### PR TITLE
fix changelog entry for --rr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Removed support for Windows
 - Replaced `--gdb` flag with `--gdb-cmd`. The `--gdb-cmd` argument specifies the gdb executable as well as all arguments you wish to pass to gdb at startup, for example `--gdb-cmd "gdb -nx"`. The existing `-g` argument is an alias for `--gdb-cmd`.
-- Removed `--rr` flag. Use `--gdb-cmd rr replay` instead.
+- Removed `--rr` flag. Use `--gdb-cmd "rr replay --"` instead.
 - Removed deprecated and hidden `--hide-gdbgui-upgrades` argument. It will now raise an error.
 
 **Additional Changes**


### PR DESCRIPTION
This is a followup to PR #362.

## Summary of changes
- [x] I have added an entry to `docs/changelog.md` :-)

- - -
I got confused first, as I only reviewed the changelog after my usual `--rr` stopped working.