### PR TITLE
show gdbgui version in more places

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,11 @@
 <!-- add an 'x' in the brackets below -->
-- [] I have added an entry to `docs/changelog.md`
+- [] I have added an entry to `CHANGELOG.md`, or an entry is not needed for this change
 
 ## Summary of changes
+<!-- 
+* fixed bug
+* added new feature 
+-->
 
 ## Test plan
 <!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## 0.15.0.0
 
-No new features, just bugfixes and compatibility fixes
+This release is focused mostly on Python 3.9 compatibility and updating dependencies
 
-- Support only Python 3.9 (though other Python versions may work)
+- Support only Python 3.9 (though other Python versions may still work)
 - Use only the threading async model for flask-socketio. No longer support gevent or eventlet.
 - [bugfix] Catch exception if gdb used in tty window crashes instead of gdbgui crashing along with it
-- Disable pagination in gdb ttyy by default. It can be turned back on with `set pagination off`.
+- Disable pagination in gdb tty by default. It can be turned back on with `set pagination off`.
 - Upgrade various dependencies for both the backend and frontend (Python and JavaScript)
+- Display gdbgui version in "about" and "session information"
 
 ## 0.14.0.2
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,7 +17,7 @@ prune docker
 prune images
 prune gdbgui/__pycache__
 prune gdbgui/server/__pycache__
-prune gdbgui/src/
+prune gdbgui/src
 
 exclude mypy.ini
 exclude .eslintrc.json

--- a/gdbgui/server/app.py
+++ b/gdbgui/server/app.py
@@ -260,7 +260,7 @@ def read_and_forward_gdb_and_pty_output():
                     pass
 
             except Exception:
-                logger.error(traceback.format_exc())
+                logger.error("caught exception, continuing:" + traceback.format_exc())
 
         debug_sessions_to_remove += check_and_forward_pty_output()
         for debug_session in set(debug_sessions_to_remove):

--- a/gdbgui/src/js/InitialStoreData.ts
+++ b/gdbgui/src/js/InitialStoreData.ts
@@ -14,7 +14,7 @@ const initial_store_data = {
   // @ts-expect-error ts-migrate(2304) FIXME: Cannot find name 'initial_data'.
   gdbgui_version: initial_data.gdbgui_version,
   latest_gdbgui_version: "(not fetched)",
-  gdb_version: 'unknown', // this is parsed from gdb's output
+  gdb_version: "unknown", // this is parsed from gdb's output
   gdb_version_array: [], // this is parsed from gdb's output
   gdb_pid: undefined,
   // @ts-expect-error ts-migrate(2304) FIXME: Cannot find name 'initial_data'.

--- a/gdbgui/src/js/InitialStoreData.ts
+++ b/gdbgui/src/js/InitialStoreData.ts
@@ -14,7 +14,7 @@ const initial_store_data = {
   // @ts-expect-error ts-migrate(2304) FIXME: Cannot find name 'initial_data'.
   gdbgui_version: initial_data.gdbgui_version,
   latest_gdbgui_version: "(not fetched)",
-  gdb_version: undefined, // this is parsed from gdb's output
+  gdb_version: 'unknown', // this is parsed from gdb's output
   gdb_version_array: [], // this is parsed from gdb's output
   gdb_pid: undefined,
   // @ts-expect-error ts-migrate(2304) FIXME: Cannot find name 'initial_data'.

--- a/gdbgui/src/js/TopBar.tsx
+++ b/gdbgui/src/js/TopBar.tsx
@@ -18,7 +18,7 @@ let onkeyup_jump_to_line = (e: any) => {
   }
 };
 
-let show_license = function () {
+let show_license = function() {
   Actions.show_modal(
     "gdbgui license",
     <React.Fragment>
@@ -42,25 +42,21 @@ let show_license = function () {
 };
 
 let About = {
-  show_about: function () {
+  show_about: function() {
     Actions.show_modal(
       "About gdbgui",
       <div>
+        <div>gdbgui, v{store.get("gdbgui_version")}</div>
+        <div>Copyright © Chad Smith</div>
         <div>
-          gdbgui, v{store.get('gdbgui_version')}
-        </div>
-        <div>
-          Copyright © Chad Smith
-        </div>
-        <div>
-          <a href='https://chadsmith.dev'>chadsmith.dev</a>
+          <a href="https://chadsmith.dev">chadsmith.dev</a>
         </div>
       </div>
     );
   }
 };
 
-let show_session_info = function () {
+let show_session_info = function() {
   Actions.show_modal(
     "session information",
     <React.Fragment>
@@ -265,7 +261,7 @@ class TopBar extends React.Component<{}, State> {
     let toggle_assm_button = "";
     if (
       this.state.source_code_state ===
-      constants.source_code_states.ASSM_AND_SOURCE_CACHED ||
+        constants.source_code_states.ASSM_AND_SOURCE_CACHED ||
       this.state.source_code_state === constants.source_code_states.ASSM_CACHED
     ) {
       // @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'string'.
@@ -288,7 +284,7 @@ class TopBar extends React.Component<{}, State> {
     let reload_button_disabled = "disabled";
     if (
       this.state.source_code_state ===
-      constants.source_code_states.ASSM_AND_SOURCE_CACHED ||
+        constants.source_code_states.ASSM_AND_SOURCE_CACHED ||
       this.state.source_code_state === constants.source_code_states.SOURCE_CACHED
     ) {
       reload_button_disabled = "";

--- a/gdbgui/src/js/TopBar.tsx
+++ b/gdbgui/src/js/TopBar.tsx
@@ -18,7 +18,7 @@ let onkeyup_jump_to_line = (e: any) => {
   }
 };
 
-let show_license = function() {
+let show_license = function () {
   Actions.show_modal(
     "gdbgui license",
     <React.Fragment>
@@ -42,15 +42,25 @@ let show_license = function() {
 };
 
 let About = {
-  show_about: function() {
+  show_about: function () {
     Actions.show_modal(
       "About gdbgui",
-      <React.Fragment>Copyright © Chad Smith, chadsmith.dev</React.Fragment>
+      <div>
+        <div>
+          gdbgui, v{store.get('gdbgui_version')}
+        </div>
+        <div>
+          Copyright © Chad Smith
+        </div>
+        <div>
+          <a href='https://chadsmith.dev'>chadsmith.dev</a>
+        </div>
+      </div>
     );
   }
 };
 
-let show_session_info = function() {
+let show_session_info = function () {
   Actions.show_modal(
     "session information",
     <React.Fragment>
@@ -59,9 +69,11 @@ let show_session_info = function() {
           <tr>
             <td>gdb version: {store.get("gdb_version")}</td>
           </tr>
-
           <tr>
             <td>gdb pid for this tab: {store.get("gdb_pid")}</td>
+          </tr>
+          <tr>
+            <td>gdbgui v{store.get("gdbgui_version")}</td>
           </tr>
         </tbody>
       </table>
@@ -253,7 +265,7 @@ class TopBar extends React.Component<{}, State> {
     let toggle_assm_button = "";
     if (
       this.state.source_code_state ===
-        constants.source_code_states.ASSM_AND_SOURCE_CACHED ||
+      constants.source_code_states.ASSM_AND_SOURCE_CACHED ||
       this.state.source_code_state === constants.source_code_states.ASSM_CACHED
     ) {
       // @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'string'.
@@ -276,7 +288,7 @@ class TopBar extends React.Component<{}, State> {
     let reload_button_disabled = "disabled";
     if (
       this.state.source_code_state ===
-        constants.source_code_states.ASSM_AND_SOURCE_CACHED ||
+      constants.source_code_states.ASSM_AND_SOURCE_CACHED ||
       this.state.source_code_state === constants.source_code_states.SOURCE_CACHED
     ) {
       reload_button_disabled = "";


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `docs/changelog.md`

## Summary of changes
- Display gdbgui version in "about" and "session information"

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
> yarn start
> nox -s serve
```
