### PR TITLE
build gdbgui as python executable (pex)

### DIFF
--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -39,5 +39,6 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: gdbgui_${{ matrix.buildname }}
-          path: ./executable/${{ matrix.buildname }} |
-          ./build/pex
+          path: |
+            ./executable/${{ matrix.buildname }}
+            ./build/pex

--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -36,7 +36,7 @@ jobs:
           nox --non-interactive --session build_executable_${{ matrix.buildname }}
       - name: Upload ${{ matrix.buildname }} executable
         # if: github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: gdbgui_${{ matrix.buildname }}
           path: |

--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -39,4 +39,5 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: gdbgui_${{ matrix.buildname }}
-          path: ./executable/${{ matrix.buildname }}
+          path: ./executable/${{ matrix.buildname }} |
+          ./build/pex

--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -40,5 +40,4 @@ jobs:
         with:
           name: gdbgui_${{ matrix.buildname }}
           path: |
-            ./executable/${{ matrix.buildname }}
-            ./build/pex
+            ./build/executable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 This release is focused mostly on Python 3.9 compatibility and updating dependencies
 
 - Support only Python 3.9 (though other Python versions may still work)
+- Build gdbgui as a [pex](https://pypi.org/project/pex/) executable.
+  - These are executable Python environments that are self-contained with the exception of requiring a specific Python version installed in the environment running the executable. The pex executables should have better compatibility than PyInstaller executables, which sometimes have missing shared libraries depending on the operating system.
 - Use only the threading async model for flask-socketio. No longer support gevent or eventlet.
 - [bugfix] Catch exception if gdb used in tty window crashes instead of gdbgui crashing along with it
 - Disable pagination in gdb tty by default. It can be turned back on with `set pagination off`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,4 +85,5 @@ gdbgui is distributed through
 
 ## Contact
 
+https://chadsmith.dev
 chadsmith.software@gmail.com

--- a/make_executable.py
+++ b/make_executable.py
@@ -13,14 +13,6 @@ from pathlib import Path
 import logging
 
 logging.basicConfig(level=logging.INFO)
-if platform.startswith("linux"):
-    platform_dir = "linux"
-elif platform.startswith("darwin"):
-    platform_dir = "mac"
-elif platform == "win32":
-    platform_dir = "windows"
-else:
-    raise Exception("Unknown platform")
 
 
 def write_spec_with_gdbgui_version_in_name(spec_path, binary_name):

--- a/make_executable.py
+++ b/make_executable.py
@@ -92,7 +92,7 @@ def generate_md5(binary: Path, output_file: Path):
 def main():
     binary_name = "gdbgui_%s" % __version__
     spec_path = "gdbgui_pyinstaller.spec"
-    distpath = (Path("executable") / platform_dir).resolve()
+    distpath = Path("build/executable").resolve()
     extension = ".exe" if platform == "win32" else ""
     binary_path = Path(distpath) / f"{binary_name}{extension}"
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -163,7 +163,7 @@ def build_executable_current_platform(session):
     session.run("yarn", "build", external=True)
     session.install(".", "PyInstaller>=4.5, <4.6")
     session.run("python", "make_executable.py")
-    build_pex(session)
+    session.nofity("build_pex")
 
 
 @nox.session(reuse_venv=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -199,7 +199,7 @@ def build_pex(session):
         "-c",
         "gdbgui",
         "-o",
-        pex_path,
+        str(pex_path),
         external=True,
     )
     checksum = hashlib.md5(pex_path.read_bytes()).hexdigest()

--- a/noxfile.py
+++ b/noxfile.py
@@ -163,7 +163,7 @@ def build_executable_current_platform(session):
     session.run("yarn", "build", external=True)
     session.install(".", "PyInstaller>=4.5, <4.6")
     session.run("python", "make_executable.py")
-    session.nofity("build_pex")
+    session.notify("build_pex")
 
 
 @nox.session(reuse_venv=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -192,7 +192,7 @@ def build_pex(session):
     """Builds a pex of gdbgui"""
     # NOTE: frontend must be built before running this
     session.install("pex==2.1.45")
-    pex_path = Path("build/pex/gdbgui.pex")
+    pex_path = Path("build/executable/gdbgui.pex")
     session.run(
         "pex",
         ".",


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`, or an entry is not needed for this change

## Summary of changes
<!-- 
* fixed bug
* added new feature 
-->
- Build gdbgui as a [pex](https://pypi.org/project/pex/) executable.
  - These are executable Python environments that are self-contained with the exception of requiring a specific Python version installed in the environment running the executable. The pex executables should have better compatibility than PyInstaller executables, which sometimes have missing shared libraries depending on the operating system.
- Included in github action, as well as a nox session  
## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
> nox -s build_pex
~/git/gdbgui/build/pex csmith@gram (cs01/add-pex*)
> md5sum gdbgui.pex
bb65703f2aa5dfef60a2b475a8341d69  gdbgui.pex
~/git/gdbgui/build/pex csmith@gram (cs01/add-pex*)
> cat gdbgui.pex.md5 
bb65703f2aa5dfef60a2b475a8341d69
> ./build/pex/gdbgui.pex
```
