### PR TITLE
bump pinned version of black

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ prettier_command = [
 
 doc_dependencies = [".", "mkdocs", "mkdocs-material"]
 lint_dependencies = [
-    "black==20.8b1",
+    "black==21.12b0",
     "vulture",
     "flake8",
     "mypy==0.782",


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [] I have added an entry to `CHANGELOG.md`, or an entry is not needed for this change
No changelog entry needed
## Summary of changes
<!-- 
* fixed bug
* added new feature 
-->
Pin version of black to avoid error
```
Traceback (most recent call last):
  File "/home/runner/work/gdbgui/gdbgui/.nox/lint/bin/black", line 5, in <module>
    from black import patched_main
  File "/home/runner/work/gdbgui/gdbgui/.nox/lint/lib/python3.9/site-packages/black/__init__.py", line 52, in <module>
    from typed_ast import ast3, ast27
  File "/home/runner/work/gdbgui/gdbgui/.nox/lint/lib/python3.9/site-packages/typed_ast/ast3.py", line 40, in <module>
    from typed_ast import _ast3
ImportError: /home/runner/work/gdbgui/gdbgui/.nox/lint/lib/python3.9/site-packages/typed_ast/_ast3.cpython-39-x86_64-linux-gnu.so: undefined symbol: _PyUnicode_DecodeUnicodeEscape
```

See https://github.com/python/typed_ast/issues/169

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
nox -s lint
```
and CI on pull request passes
