### PR TITLE
deps: bump greenlet to 2.0.2 (for py3.11 support)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ flask-compress==1.10.1
     # via -r requirements.in
 flask-socketio==5.1.1
     # via -r requirements.in
-greenlet==1.1.2
+greenlet==2.0.2
     # via eventlet
 itsdangerous==2.0.1
     # via flask


### PR DESCRIPTION
- [] I have added an entry to `CHANGELOG.md`, or an entry is not needed for this change

## Summary of changes

Bump greenlet to 2.0.2 for python 3.11 support (see changelog in [here](https://github.com/python-greenlet/greenlet/blob/d80abc7b410421268da6abbdfe6a629f0ca0b23f/CHANGES.rst#L16))


## Test plan

Would be covered in [homebrew-core version bump](https://github.com/Homebrew/homebrew-core/pull/122822)