### PR TITLE
Support Python 3.11 - Fix 447

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 88
-ignore = E501, E203, W503, E402, E231  # line length, whitespace before ':', line break before binary operator,  module level import not at top of file
+ignore = E501, E203, W503, E402, E231
+# line length, whitespace before ':', line break before binary operator,  module level import not at top of file

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,7 +25,7 @@ lint_dependencies = [
     "black==22.3.0",
     "vulture",
     "flake8",
-    "mypy==0.782",
+    "mypy==1.2.0",
     "check-manifest",
 ]
 vulture_whitelist = ".vulture_whitelist.py"

--- a/noxfile.py
+++ b/noxfile.py
@@ -162,11 +162,11 @@ def publish_docs(session):
     session.run("mkdocs", "gh-deploy")
 
 
-@nox.session(reuse_venv=True, python="3.10")
+@nox.session(reuse_venv=True, python="3.11")
 def build_executables_current_platform(session):
     session.run("yarn", "install", external=True)
     session.run("yarn", "build", external=True)
-    session.install(".", "PyInstaller==5.1")
+    session.install(".", "PyInstaller==5.10.1")
     session.run("python", "make_executable.py")
     session.notify("build_pex")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ import glob
 
 nox.options.reuse_existing_virtualenvs = True
 nox.options.sessions = ["tests", "lint", "docs"]
-python = ["3.10"]
+python = ["3.11"]
 
 prettier_command = [
     "npx",

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ flask-compress==1.10.1
     # via -r requirements.in
 flask-socketio==5.1.1
     # via -r requirements.in
-greenlet==1.1.2
+greenlet==2.0.2
     # via eventlet
 itsdangerous==2.0.1
     # via flask


### PR DESCRIPTION
### Support Python 3.11

<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`, or an entry is not needed for this change
  - this should be done by the package maintainer, when a new version is released

- some of the problems are introduced by fixed requirements introduced in version 0.15.1.0
- build will run successfully with python3.11
  - tested on linux (`nox -s build_executables_current_platform`)
  - develop mode is working `nox -s develop`

## Summary of changes
<!-- 
* fixed bug
* added new feature 
-->
- fix #447 
- this will bump some the versions of some requirements
- update the noxfile to support python 3.11
- fix the flake8 config file: comments should start in an extra line

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running `nox`

```
nox > * tests-3.11: success
nox > * lint: failed
nox > * docs: success
nox > * cover: success
```

One of the linting errors is also handled with this PR. This change/PR has nothing to do with failed lint tests. They should be handled separately.
What failed?

- some datatypes - test by `mypy`
```
gdbgui/server/constants.py:14: error: Argument 1 to "Path" has incompatible type "Optional[Any]"; expected "Union[str, PathLike[str]]"  [arg-type]
gdbgui/server/sessionmanager.py:67: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
gdbgui/server/sessionmanager.py:103: error: Argument 1 to "IoManager" has incompatible type "FileIO"; expected "BufferedWriter"  [arg-type]
gdbgui/server/sessionmanager.py:104: error: Argument 2 to "IoManager" has incompatible type "FileIO"; expected "BufferedReader"  [arg-type]
```

- some missing dist files - test by `check-manifest`
```
lists of files in version control and sdist do not match!
missing from VCS:
  gdbgui/static/js/dashboard.js
  gdbgui/static/js/dashboard.js.map
  gdbgui/static/js/main.js
  gdbgui/static/js/main.js.map
```