### PR TITLE
Update RightSidebar on watchpoint-trigger, as well as on breakpoint-hit and stepping-range-end

### DIFF
--- a/gdbgui/src/js/process_gdb_response.tsx
+++ b/gdbgui/src/js/process_gdb_response.tsx
@@ -274,6 +274,7 @@ const process_gdb_response = function(response_array: any) {
           Actions.inferior_program_exited();
         } else if (
           r.payload.reason.includes("breakpoint-hit") ||
+          r.payload.reason.includes("watchpoint-trigger") ||
           r.payload.reason.includes("end-stepping-range")
         ) {
           if (r.payload["new-thread-id"]) {


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`, or an entry is not needed for this change

## Summary of changes
<!-- 
* Cause RightSidebar displays (Registers, Memory etc.) to be updated when a watchpoint is triggered, as well as when a breakpoint or stepping-range end is hit
-->

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
watch *0x<_addr_to_watch_>
continue
```
