### PR TITLE
Memory: Show all printable ASCII in hexdump

### DIFF
--- a/gdbgui/src/js/Memory.tsx
+++ b/gdbgui/src/js/Memory.tsx
@@ -85,7 +85,7 @@ class Memory extends React.Component<{}, State> {
       }
       let hex_value = store.get("memory_cache")[hex_addr];
       hex_vals_for_this_addr.push(hex_value);
-      let char = String.fromCharCode(parseInt(hex_value, 16)).replace(/\W/g, ".");
+      let char = String.fromCharCode(parseInt(hex_value, 16)).replace(/[^ -~]/g, ".");
       char_vals_for_this_addr.push(
         <span key={i} className="memory_char">
           {char}


### PR DESCRIPTION
Previously, only characters in the "word" class were shown in the memory hexdump.  These are like alphabetic and numeric characters.  Other printable characters like spaces and  punctuation were replaced with a ".".

This commits shows all printable ASCII characters, and only does the "." replacement for control characters and 127.

<!-- add an 'x' in the brackets below -->
- [X] I have added an entry to `CHANGELOG.md`, or an entry is not needed for this change

I don't know if it's needed.  I'm happy to provide one if requested.

## Summary of changes
* Made all printable ASCII characters show up in the memory hex dump, which is consistent with most hex dumps

## Test plan
It hasn't been extensively tested, but the result looked good to me, including when the dump contained stuff that might have been HTML.  You can verify the behavior yourself by opening the memory section and looking at the memory of any running program.