### PR TITLE
Fix setting echo attribute in ptylib on Unix98 systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # gdbgui release history
 
+## 0.15.2.1
+- Fix setting echo attribute in ptylib on Unix98 systems
+
 ## 0.15.2.0
 - Update default python version to 3.12
 - utf-8 decode error bugfix

--- a/gdbgui/server/ptylib.py
+++ b/gdbgui/server/ptylib.py
@@ -45,17 +45,18 @@ class Pty:
             (master, slave) = pty.openpty()
             self.stdin = master
             self.stdout = master
+            self.slave = slave
             self.name = os.ttyname(slave)
             self.set_echo(echo)
 
     def set_echo(self, echo_on: bool) -> None:
-        (iflag, oflag, cflag, lflag, ispeed, ospeed, cc) = termios.tcgetattr(self.stdin)
+        (iflag, oflag, cflag, lflag, ispeed, ospeed, cc) = termios.tcgetattr(self.slave)
         if echo_on:
             lflag = lflag & termios.ECHO  # type: ignore
         else:
             lflag = lflag & ~termios.ECHO  # type: ignore
         termios.tcsetattr(
-            self.stdin,
+            self.slave,
             termios.TCSANOW,
             [iflag, oflag, cflag, lflag, ispeed, ospeed, cc],
         )


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`, or an entry is not needed for this change

## Summary of changes

gdbgui is unable to start the debugger on Unix98 systems like Solaris and AIX, because it attempts to set echo attribute on the master end of the pty pair. This is not allowed and should be done on the child end instead. 

See also https://github.com/amoffat/sh/issues/143.

## Test plan

Tested by running gdbgui on OpenIndiana (Illumos kernel derived from Solaris).
