### PR TITLE
start browser in a new thread and point directly to the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # gdbgui release history
 
+- start browser in a new thread to avoid connection errors
+
 ## 0.15.3.0
 - Update default python version to 3.13
 

--- a/gdbgui/server/server.py
+++ b/gdbgui/server/server.py
@@ -1,5 +1,6 @@
 import os
 import socket
+import threading
 import webbrowser
 
 from .constants import DEFAULT_HOST, DEFAULT_PORT, colorize
@@ -82,7 +83,12 @@ def run_server(
             text = ("Opening gdbgui with %s at " + protocol + "%s:%d") % args
             print(colorize(text))
             b = webbrowser.get(browsername) if browsername else webbrowser
-            b.open(url_with_prefix)
+
+            # open the dashboard directly in a new tab/window in a new thread
+            def open_browser_func():
+                b.open_new_tab(url_with_prefix)
+
+            threading.Thread(target=open_browser_func).start()
         else:
             print(colorize(f"View gdbgui at {protocol}{url[0]}:{url[1]}"))
         print(


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`, or an entry is not needed for this change

## Summary of changes
<!-- 
* fixed bug
* added new feature 
-->
This fixes somewhat of a "bug", where on first launch the browser will regularly open `http://127.0.0.1:5000` and display an "Unable to connect" error.

<img width="1194" height="427" alt="image" src="https://github.com/user-attachments/assets/3e7eef72-c5f0-43ca-aacc-6a14498f3dd8" />

I'm assuming this is because the browser is launched by the main thread in a state where the server hasn't had enough time to initialize and serve the page in question.

This PR just moves that to another thread to both speed up server initialization and avoid the error altogether.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
Running the gui locally