### PR TITLE
Add Docker support (Dockerfile + docker-compose.yml)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+gdbgui/static/js/main.js
+__pycache__
+*.pyc
+*.pyo
+.git
+.pytest_cache
+gdbgui.egg-info
+gdbgui/server/uploads

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# ── Stage 1: build the React/Webpack frontend ─────────────────────────────
+FROM node:20-slim AS frontend-builder
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY . .
+# Webpack 4 requires --openssl-legacy-provider; pass it directly to node
+# to avoid NODE_OPTIONS restrictions on Node 17+.
+RUN NODE_ENV=production node --openssl-legacy-provider \
+    node_modules/.bin/webpack --mode production --config webpack.config.js
+
+# ── Stage 2: Python runtime ────────────────────────────────────────────────
+FROM python:3.13-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential g++ gdb libstdc++-12-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# python:3.13-slim installs the stdlib at /usr/local/lib/python3.13, but
+# GDB's embedded Python looks at /usr/lib/python3.13 — fix sys.path so
+# libstdc++ pretty-printers load correctly.
+RUN printf 'set auto-load safe-path /\nset breakpoint pending on\npython\nimport sys\nfor p in ["/usr/local/lib/python3.13","/usr/local/lib/python3.13/lib-dynload","/usr/share/gcc/python"]:\n    if p not in sys.path: sys.path.insert(0, p)\nfrom libstdcxx.v6.printers import register_libstdcxx_printers\nregister_libstdcxx_printers(None)\nend\n' > /root/.gdbinit
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+COPY . .
+COPY --from=frontend-builder /app/gdbgui/static/js/ ./gdbgui/static/js/
+
+RUN pip install -e . --no-deps
+
+EXPOSE 5000
+CMD ["python", "-m", "gdbgui", "--host=0.0.0.0", "--port=5000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  gdbgui:
+    build: .
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./gdbgui/server/uploads:/app/gdbgui/server/uploads
+    environment:
+      - PYTHONUNBUFFERED=1
+      - PYTHONDONTWRITEBYTECODE=1
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined


### PR DESCRIPTION
## Summary

Closes #474 — adds a baseline Docker environment as requested.

- **Multi-stage Dockerfile**: Node 20 builds the React/Webpack frontend; Python 3.13-slim runs the gdbgui server. Keeps the final image small.
- **libstdc++ pretty-printers** wired up via `.gdbinit` so STL containers display correctly in GDB (fixes `sys.path` for the `python:3.13-slim` layout).
- `set breakpoint pending on` in `.gdbinit` so pending breakpoints resolve after the binary loads.
- **docker-compose.yml** grants `SYS_PTRACE` (required by GDB) and uses `seccomp:unconfined` for full ptrace compatibility.
- **.dockerignore** excludes `node_modules` and build artifacts.

## Quick start

```bash
docker-compose up --build
# open http://localhost:5000
```

## Notes

**Webpack 4 + Node 17+ incompatibility**: `cross-env NODE_OPTIONS=--openssl-legacy-provider` is rejected by Node 17+. Worked around by invoking webpack directly through `node --openssl-legacy-provider ...` in the Dockerfile. Upgrading to Webpack 5 would be a cleaner long-term fix but is out of scope for this PR.

## Test plan

- [ ] `docker-compose up --build` succeeds
- [ ] `http://localhost:5000` loads the gdbgui UI
- [ ] Uploading and running a C++ binary hits breakpoints correctly
- [ ] STL container variables display via pretty-printers (e.g. `std::vector<int>` shows `{1, 2, 3}` instead of a raw pointer)